### PR TITLE
Changes to Dockerfile and README.md

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+docker-compose.yaml
+Dockerfile
+.git/
+.github/
+.gitignore
+main_test.go
+Makefile
+README.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: '1.23.x'
 
       - name: Install Dependencies
         run: go get ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM golang:1.22 as gobuild
-ARG VERSION=latest
-
+ARG GOVERSION=1.23.1-alpine3.20
+FROM golang:$GOVERSION AS builder
+RUN apk add -q --no-cache tzdata
 WORKDIR /air-pollution-service
 ADD go.mod go.sum main.go ./
 ADD config ./config
 ADD internal ./internal
 ADD docs ./docs
+RUN go build -ldflags="-w -s -extldflags=-static" -a -o ./bin/server
 
-RUN go build -ldflags '-w -s' -a -o ./bin/server
-
-FROM gcr.io/distroless/base
-
-COPY --from=gobuild /air-pollution-service/bin/server /air-pollution-service/bin/server
-
+FROM scratch
+ENV TZ="Europe/Berlin"
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /air-pollution-service/bin/server /air-pollution-service/bin/server
 ENTRYPOINT ["/air-pollution-service/bin/server"]
+

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ go run main.go
 * Download the raw data to a file, e.g. `/data/air-pollution.csv`.
 ```bash
 docker pull ghcr.io/hbtgmbh/air-pollution-service:latest
-docker run --mount type=bind,src=/data,dst=/data --publish 8080:8080 --env AIR_POLLUTION_FILE=/data/air-pollution.csv ghcr.io/hbtgmbh/air-pollution-service:latest
+docker run -v /data:/data -p 8080:8080 -e AIR_POLLUTION_FILE=/data/air-pollution.csv ghcr.io/hbtgmbh/air-pollution-service:latest
 ```
 
 ## 📝 TODO


### PR DESCRIPTION
Changes:
- upgrade Go from 1.22 to 1.23.1
- use Go with Alpine 3.20 (instead of Debian) as builder
- build Go with explicit static linking (to be able to use a scratch base image without a C standard library - cuts final image size roughly in half)
- use scratch base image (with additional tzdata)
- set TZ to Europe/Berlin in runtime image
- use condensed arguments/forms for `docker run` command in README.md
- add .dockerignore (to avoid rebuilding when e.g. README.md changes)