### PR TITLE
refactor(test): move tests to *_test package

### DIFF
--- a/internal/csv/csv_test.go
+++ b/internal/csv/csv_test.go
@@ -1,4 +1,4 @@
-package csv
+package csv_test
 
 import "testing"
 

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,4 +1,4 @@
-package model
+package model_test
 
 import "testing"
 

--- a/internal/resource/countries_test.go
+++ b/internal/resource/countries_test.go
@@ -1,12 +1,13 @@
-package resource
+package resource_test
 
 import (
 	"air-pollution-service/internal/model"
+	"air-pollution-service/internal/resource"
 	"context"
 	"encoding/json"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -49,12 +50,12 @@ func TestCountriesGetNonExisting(t *testing.T) {
 	ctx := chi.NewRouteContext()
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
 	ctx.URLParams.Add("id", "Schlaraffenland")
-	countryHandler := CountryResource{Storage: fakeCountryStorage{[]*model.Country{}}}
+	countryHandler := resource.CountryResource{Storage: fakeCountryStorage{[]*model.Country{}}}
 
 	countryHandler.Get(w, req)
 	res := w.Result()
 	defer res.Body.Close()
-	_, err := ioutil.ReadAll(res.Body)
+	_, err := io.ReadAll(res.Body)
 	assert.Nil(t, err)
 	assert.Equal(t, 404, res.StatusCode)
 }
@@ -65,7 +66,7 @@ func TestCountriesGetExisting(t *testing.T) {
 	ctx := chi.NewRouteContext()
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
 	ctx.URLParams.Add("id", "Schlaraffenland")
-	countryHandler := CountryResource{Storage: fakeCountryStorage{[]*model.Country{{
+	countryHandler := resource.CountryResource{Storage: fakeCountryStorage{[]*model.Country{{
 		Name: "Schlaraffenland",
 		Code: "SCH",
 		Id:   "sch",
@@ -74,11 +75,11 @@ func TestCountriesGetExisting(t *testing.T) {
 	countryHandler.Get(w, req)
 	res := w.Result()
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	assert.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 
-	country := countryResponse{}
+	country := resource.CountryResponse{}
 	err = json.Unmarshal(data, &country)
 	assert.Nil(t, err)
 	assert.Equal(t, "Schlaraffenland", country.Name)

--- a/internal/resource/emissions_test.go
+++ b/internal/resource/emissions_test.go
@@ -1,12 +1,13 @@
-package resource
+package resource_test
 
 import (
 	"air-pollution-service/internal/model"
+	"air-pollution-service/internal/resource"
 	"context"
 	"encoding/json"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -58,7 +59,7 @@ func TestEmissionsListByYear(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	ctx := chi.NewRouteContext()
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
-	emissionsHandler := EmissionResource{Storage: fakeEmissionsStorage{[]*model.Emissions{{
+	emissionsHandler := resource.EmissionResource{Storage: fakeEmissionsStorage{[]*model.Emissions{{
 		NOxEmissions: 1,
 	}, {
 		NOxEmissions: 2,
@@ -69,7 +70,7 @@ func TestEmissionsListByYear(t *testing.T) {
 	emissionsHandler.ListByYear(w, req)
 	res := w.Result()
 	defer res.Body.Close()
-	_, err := ioutil.ReadAll(res.Body)
+	_, err := io.ReadAll(res.Body)
 	assert.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 
@@ -81,7 +82,7 @@ func TestEmissionsListByCountry(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	ctx := chi.NewRouteContext()
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
-	emissionsHandler := EmissionResource{Storage: fakeEmissionsStorage{[]*model.Emissions{{
+	emissionsHandler := resource.EmissionResource{Storage: fakeEmissionsStorage{[]*model.Emissions{{
 		NOxEmissions: 1,
 	}, {
 		NOxEmissions: 2,
@@ -92,7 +93,7 @@ func TestEmissionsListByCountry(t *testing.T) {
 	emissionsHandler.ListByCountry(w, req)
 	res := w.Result()
 	defer res.Body.Close()
-	_, err := ioutil.ReadAll(res.Body)
+	_, err := io.ReadAll(res.Body)
 	assert.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 
@@ -105,7 +106,7 @@ func TestEmissionsGetByCountry(t *testing.T) {
 	ctx := chi.NewRouteContext()
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
 	ctx.URLParams.Add("id", "Schlaraffenland")
-	emissionsHandler := EmissionResource{Storage: fakeEmissionsStorage{[]*model.Emissions{{
+	emissionsHandler := resource.EmissionResource{Storage: fakeEmissionsStorage{[]*model.Emissions{{
 		NOxEmissions: 10,
 	}, {
 		NOxEmissions: 2,
@@ -116,11 +117,11 @@ func TestEmissionsGetByCountry(t *testing.T) {
 	emissionsHandler.GetByCountry(w, req)
 	res := w.Result()
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	assert.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 
-	airPollutionEmissions := AirPollutionResponse{}
+	airPollutionEmissions := resource.AirPollutionResponse{}
 	err = json.Unmarshal(data, &airPollutionEmissions)
 	assert.Nil(t, err)
 	assert.Equal(t, 5.0, airPollutionEmissions.NOxEmissions.Average)
@@ -134,7 +135,7 @@ func TestEmissionsGetByYear(t *testing.T) {
 	ctx := chi.NewRouteContext()
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, ctx))
 	ctx.URLParams.Add("year", "666")
-	emissionsHandler := EmissionResource{Storage: fakeEmissionsStorage{[]*model.Emissions{{
+	emissionsHandler := resource.EmissionResource{Storage: fakeEmissionsStorage{[]*model.Emissions{{
 		NOxEmissions: 10,
 	}, {
 		NOxEmissions: 2,
@@ -145,11 +146,11 @@ func TestEmissionsGetByYear(t *testing.T) {
 	emissionsHandler.GetByYear(w, req)
 	res := w.Result()
 	defer res.Body.Close()
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	assert.Nil(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 
-	airPollutionEmissions := AirPollutionResponse{}
+	airPollutionEmissions := resource.AirPollutionResponse{}
 	err = json.Unmarshal(data, &airPollutionEmissions)
 	assert.Nil(t, err)
 	assert.Equal(t, 5.0, airPollutionEmissions.NOxEmissions.Average)

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -8,21 +8,21 @@ import (
 )
 
 // CountryResponse renderer type for country data
-type countryResponse struct {
+type CountryResponse struct {
 	Id   string `json:"id"`
 	Name string `json:"name"`
 	Code string `json:"code"`
 } // @name CountryResponse
 
-func newCountryResponse(country *model.Country) countryResponse {
-	return countryResponse{
+func newCountryResponse(country *model.Country) CountryResponse {
+	return CountryResponse{
 		Id:   country.Id,
 		Name: country.Name,
 		Code: country.Code,
 	}
 }
 
-func (hr countryResponse) Render(w http.ResponseWriter, r *http.Request) error {
+func (hr CountryResponse) Render(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 

--- a/internal/store/storage_test.go
+++ b/internal/store/storage_test.go
@@ -1,4 +1,4 @@
-package store
+package store_test
 
 import "testing"
 


### PR DESCRIPTION
To avoid accidentally using implementation details of the package within tests.
Tests should only use/test public APIs.