### PR TITLE
Sleep before shutdown (SIGTERM)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,13 +6,13 @@ import (
 )
 
 type Conf struct {
-	Server                      ConfServer
-	AirPollutionFile            string `env:"AIR_POLLUTION_FILE,default=air-pollution.csv"`
-	SleepDurationBeforeShutdown string `env:"SLEEP_DURATION_BEFORE_SHUTDOWN,default=10s"`
+	Server           ConfServer
+	AirPollutionFile string `env:"AIR_POLLUTION_FILE,default=air-pollution.csv"`
 }
 
 type ConfServer struct {
-	Port int `env:"SERVER_PORT,default=8080"`
+	Port                        int    `env:"SERVER_PORT,default=8080"`
+	SleepDurationBeforeShutdown string `env:"SLEEP_DURATION_BEFORE_SHUTDOWN,default=10s"`
 }
 
 func New() *Conf {

--- a/config/config.go
+++ b/config/config.go
@@ -6,8 +6,9 @@ import (
 )
 
 type Conf struct {
-	Server           ConfServer
-	AirPollutionFile string `env:"AIR_POLLUTION_FILE,default=air-pollution.csv"`
+	Server                      ConfServer
+	AirPollutionFile            string `env:"AIR_POLLUTION_FILE,default=air-pollution.csv"`
+	SleepDurationBeforeShutdown string `env:"SLEEP_DURATION_BEFORE_SHUTDOWN,default=10s"`
 }
 
 type ConfServer struct {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 )
 
 func main() {
@@ -61,7 +62,22 @@ func main() {
 	}()
 
 	log.Printf("Server started sucessfully!")
-	<-c
+	sig := <-c
+	if sig == syscall.SIGTERM {
+		// Build "sleep before shutdown" into the application to handle deployment
+		// scenarios where the service might still receive traffic after a shutdown
+		// such as in a Kubernetes rolling deployment/update. This will allow the
+		// service to gracefully shutdown after a configurable duration after we can
+		// be sure that all traffic has been shifted to the new version.
+		// See also: https://learnk8s.io/graceful-shutdown
+		parsedSleepDuration, err := time.ParseDuration(conf.SleepDurationBeforeShutdown)
+		if err != nil {
+			log.Printf("Failed to parse SLEEP_DURATION_BEFORE_SHUTDOWN duration %s. Won't sleep: %s", conf.SleepDurationBeforeShutdown, err)
+		} else {
+			log.Printf("Waiting for %s before shutting down...", parsedSleepDuration.String())
+			time.Sleep(parsedSleepDuration)
+		}
+	}
 	log.Printf("Shutting down server gracefully...")
 	err = server.Shutdown(context.Background())
 	if err != nil {


### PR DESCRIPTION
To handle zero-downtime deployment updates in
environments where traffic can still be sent
for some time to the old version/pods.

SIGINT (Ctrl+C) is unaffected by this, because
in (local) Shell environments one usually wants
the shutdown to happen immediately.